### PR TITLE
Force the script to use the default locale

### DIFF
--- a/check_galera_cluster
+++ b/check_galera_cluster
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+LANG=C
 
 PROGNAME=`basename $0`
 VERSION="Version 1.1.5"


### PR DESCRIPTION
In french for example, decimal separator is a comma, not a period.
So it breaks mathematical computation like the wsrep_flow_control_paused one.