### PR TITLE
Bugfix: bash syntax

### DIFF
--- a/check_galera_cluster
+++ b/check_galera_cluster
@@ -177,7 +177,7 @@ if [ -z "$rFlowControl" ]; then
   unknAlerts=$(($unknAlerts+1))
 fi
 
-if [ $(echo "$rFlowControl > $fcp" | bc) = 1 ]; then
+if [ $(echo "$rFlowControl > $fcp" | bc) == 1 ]; then
   echo "CRITICAL: wsrep_flow_control_paused is > $fcp"
   critAlerts=$(($criticalAlerts+1))
 fi


### PR DESCRIPTION
comparsion with '==', not '='
